### PR TITLE
Fix openssl 1.1.1 issue

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     - 0003-Don-t-use-deprecated-API-with-openssl-1.1.patch  # [unix]
 
 build:
-  number: 1003
+  number: 1004
   skip: true  # [win and vc<14]
   run_exports:
     # https://abi-laboratory.pro/tracker/timeline/mysql-connector-c/
@@ -33,6 +33,7 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - make        # [unix]
+    - openssl     # [not win]
   host:
     - openssl     # [not win]
     - msinttypes  # [win and vc<14]


### PR DESCRIPTION
I have a hunch that https://github.com/conda-forge/mysql-connector-c-feedstock/issues/8 is related to a mismatch between the `openssl` that is used during the build phase and that of the run phase. I'm not 100% sure, but looking at some of the build logs, it looks like `openssl` version 1.02 is present when the library is build, but then 1.1.1 is the actual requirement. If you also look at the `build.sh`, the `with_ssl` variable is set to `system`, which caries a warning in the [connector documentation](https://dev.mysql.com/doc/connector-cpp/8.0/en/connector-cpp-source-configuration-options.html) against issues with `cmake` using an incorrect version (the documentation is for the newer c++ library, but the advice might hold here as well). I'm wondering if `system` should be replaced with an explicit path as the documentation suggests as well. 