### PR TITLE
update openssl 1.1 patch

### DIFF
--- a/recipe/0003-Don-t-use-deprecated-API-with-openssl-1.1.patch
+++ b/recipe/0003-Don-t-use-deprecated-API-with-openssl-1.1.patch
@@ -1,7 +1,7 @@
-From 13c24a9109e86c8daeccdfc184d42b18388bcf4a Mon Sep 17 00:00:00 2001
+From 7961393dd45e4ad1cdc7544b4bba2e98a5d2760c Mon Sep 17 00:00:00 2001
 From: eroen <eroen@occam.eroen.eu>
 Date: Fri, 20 Jan 2017 14:43:53 +0100
-Subject: [PATCH 3/3] Don't use deprecated API with openssl 1.1
+Subject: [PATCH] Don't use deprecated API with openssl 1.1
 
 If openssl 1.1.0 is built with `--api=1.1 disable-deprecated`, using
 deprecated APIs causes build errors.
@@ -9,10 +9,10 @@ deprecated APIs causes build errors.
 X-Gentoo-Bug: 606600
 X-Gentoo-Bug-URL: https://bugs.gentoo.org/show_bug.cgi?id=606600
 ---
- mysys_ssl/my_aes_openssl.cc | 54 ++++++++++++++++++++++++++-----------
- sql-common/client.c         | 16 +++++++++--
- vio/viossl.c                |  8 ++++++
- vio/viosslfactories.c       | 23 ++++++++++++++++
+ mysys_ssl/my_aes_openssl.cc | 54 ++++++++++++++++++++++++++++++++-------------
+ sql-common/client.c         | 16 ++++++++++++--
+ vio/viossl.c                |  8 +++++++
+ vio/viosslfactories.c       | 23 +++++++++++++++++++
  4 files changed, 84 insertions(+), 17 deletions(-)
 
 diff --git a/mysys_ssl/my_aes_openssl.cc b/mysys_ssl/my_aes_openssl.cc
@@ -188,16 +188,30 @@ index 5622cb7..94b0f09 100644
  #ifndef DBUG_OFF
  
  static void
-@@ -310,7 +316,9 @@ void vio_ssl_delete(Vio *vio)
+@@ -310,8 +316,10 @@ void vio_ssl_delete(Vio *vio)
    }
  
  #ifndef HAVE_YASSL
 +#if OPENSSL_VERSION_NUMBER < 0x10100000L
    ERR_remove_thread_state(0);
-+#endif
  #endif
++#endif
  
    vio_delete(vio);
+ }
+@@ -427,7 +427,12 @@
+       for (j = 0; j < n; j++)
+       {
+         SSL_COMP *c = sk_SSL_COMP_value(ssl_comp_methods, j);
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+         DBUG_PRINT("info", ("  %d: %s\n", c->id, c->name));
++#else  /* OPENSSL_VERSION_NUMBER < 0x10100000L */
++        DBUG_PRINT("info",
++                   ("  %d: %s\n", SSL_COMP_get_id(c), SSL_COMP_get0_name(c)));
++#endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
+       }
+   }
+ #endif
 diff --git a/vio/viosslfactories.c b/vio/viosslfactories.c
 index da5449a..87b30c3 100644
 --- a/vio/viosslfactories.c
@@ -229,8 +243,8 @@ index da5449a..87b30c3 100644
 +#else
 +    if (! DH_set0_pqg(dh,
 +              BN_bin2bn(dh2048_p,sizeof(dh2048_p),NULL),
-+              BN_bin2bn(dh2048_g,sizeof(dh2048_g),NULL),
-+              NULL))
++              NULL,
++              BN_bin2bn(dh2048_g,sizeof(dh2048_g),NULL)))
 +    {
 +#endif
        DH_free(dh);
@@ -282,5 +296,5 @@ index da5449a..87b30c3 100644
  }
  
 -- 
-2.18.0
+2.11.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,10 +17,11 @@ source:
     - 0001-Add-definition-for-lldiv_t.patch  # [win and vc<14]
     - 0001-CPPFLAGS-can-have-more-than-one-compiler-definition.patch
     - 0002-GCC-7-Fix-empty-string-comparison-error.patch
+    # Copied from https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-db/mysql-connector-c/files/6.1.11-openssl-1.1.patch
     - 0003-Don-t-use-deprecated-API-with-openssl-1.1.patch  # [unix]
 
 build:
-  number: 1003
+  number: 1004
   skip: true  # [win and vc<14]
   run_exports:
     # https://abi-laboratory.pro/tracker/timeline/mysql-connector-c/


### PR DESCRIPTION
Update 0003-Don-t-use-deprecated-API-with-openssl-1.1.patch from the
gentoo repository. This incorporates the changes from:
https://gitweb.gentoo.org/repo/gentoo.git/commit/dev-db/mysql-connector-c/files/6.1.11-openssl-1.1.patch?id=0c5fdeb6d081cae27524f042d0507dd58716bd51
https://gitweb.gentoo.org/repo/gentoo.git/commit/dev-db/mysql-connector-c/files/6.1.11-openssl-1.1.patch?id=f3738737cebd87a225cc00de863a94d821f00a8f

Add comment indicating the source of the patch.

Bump the build number.

closes #8

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
